### PR TITLE
Add True return to the build method

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -26,6 +26,7 @@ class Build {
         for <resources/lib libjust-for-tests resources/bin P6-Fcntl> -> $dir, $obj {
           make($workdir, $dir, :outname($obj));
         }
+        True;
     }
 }
 


### PR DESCRIPTION
zef checks the return of the build method, and will fail the build
if it isn't "True"

Should fix https://github.com/perl6/ecosystem-unbitrot/issues/226